### PR TITLE
fix: Should set output.library.name for umd type

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,12 +24,19 @@ module.exports = {
   output: {
     path: path.join(__dirname, 'lib'),
     filename: 'index.js',
-    /**
-     * An object with { root, amd, commonjs, ... } is only allowed for libraryTarget: 'umd'.
-     * It's not allowed for other library targets.
-     * https://webpack.js.org/configuration/externals/#object
-     */
     library: {
+      name: {
+        root: 'TokenInput',
+        commonjs2: 'token-input',
+        commonjs: 'token-input',
+        amd: 'token-input',
+      },
+      /**
+       * Fix issue `Minified React error #321`
+       * An object with { root, amd, commonjs, ... } is only allowed for libraryTarget: 'umd'.
+       * It's not allowed for other library targets.
+       * https://webpack.js.org/configuration/externals/#object
+       */
       type: 'umd',
     },
   },
@@ -37,7 +44,8 @@ module.exports = {
    * Fix issue `Minified React error #321` when import from npm
    * https://reactjs.org/docs/error-decoder.html?invariant=321
    *
-   * Solution:https://github.com/facebook/react/issues/16029#issuecomment-570912067
+   * Solution:
+   * https://github.com/facebook/react/issues/16029#issuecomment-570912067
    */
   externals: {
     react: {


### PR DESCRIPTION
### Purpose
- Fix umd without a name issue

### Issue
- umd without a name issue

### Root cause
- Do not set the name

### Solution
- Set the name
