### PR TITLE
chore: the ignored folder name should be docs/

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,5 @@
 node_modules/
 coverage/
-doc/
+docs/
 dist/
 lib/

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,5 +1,5 @@
 node_modules/
 coverage/
-doc/
+docs/
 dist/
 lib/


### PR DESCRIPTION
The ignored folder name should be `docs/` not `doc/`