### PR TITLE
chore: do not need to specific node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,8 +104,5 @@
     "webpack": "^5.90.3",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^4.11.1"
-  },
-  "engines": {
-    "node": ">=v18.19.0"
   }
 }


### PR DESCRIPTION
Only dev mode this node v18 but when using this library we do not need to care the node version.