### PR TITLE
fix:  incorrect peer dependency of @testing-library/react-hooks and react v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@babel/preset-env": "^7.24.0",
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
-    "@testing-library/react-hooks": "^8.0.1",
+    "@testing-library/react": "^14.2.1",
     "@types/jest": "^29.5.12",
     "@types/react-input-autosize": "^2.2.4",
     "@typescript-eslint/eslint-plugin": "^7.1.0",

--- a/src/hooks/usePredefinedKeyDownHandlers.test.js
+++ b/src/hooks/usePredefinedKeyDownHandlers.test.js
@@ -72,7 +72,7 @@ describe('usePredefinedKeyDownHandlers() default setting', () => {
       'function',
     );
     emptyInputValueResult.current.handleBackspaceKeyDown(KEY_DOWN_EVENT);
-    expect(onLastTokenDelete).toBeCalledTimes(1);
+    expect(onLastTokenDelete).toHaveBeenCalledTimes(1);
   });
 
   it('should return `handleTabKeyDown`', () => {
@@ -121,8 +121,8 @@ describe('usePredefinedKeyDownHandlers() default setting', () => {
 
     expect(typeof result.current.handleEnterKeyDown).toBe('function');
     result.current.handleEnterKeyDown(KEY_DOWN_EVENT);
-    expect(handleTokensCreate).toBeCalledTimes(1);
-    expect(handleTokensCreate).toBeCalledWith(inputValue);
+    expect(handleTokensCreate).toHaveBeenCalledTimes(1);
+    expect(handleTokensCreate).toHaveBeenCalledWith(inputValue);
   });
 
   it('should return `handleEscapeKeyDown`', () => {
@@ -146,8 +146,8 @@ describe('usePredefinedKeyDownHandlers() default setting', () => {
 
     expect(typeof result.current.handleEscapeKeyDown).toBe('function');
     result.current.handleEscapeKeyDown(KEY_DOWN_EVENT);
-    expect(handleInputValueUpdate).toBeCalledTimes(1);
-    expect(handleInputValueUpdate).toBeCalledWith(inputInitValue);
+    expect(handleInputValueUpdate).toHaveBeenCalledTimes(1);
+    expect(handleInputValueUpdate).toHaveBeenCalledWith(inputInitValue);
   });
 });
 
@@ -191,7 +191,7 @@ describe('usePredefinedKeyDownHandlers().handleBackspaceKeyDown()', () => {
         'function',
       );
       emptyInputValueResult.current.handleBackspaceKeyDown(KEY_DOWN_EVENT);
-      expect(onLastTokenDelete).toBeCalledTimes(1);
+      expect(onLastTokenDelete).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -274,9 +274,9 @@ describe('usePredefinedKeyDownHandlers().handleTabKeyDown()', () => {
 
       expect(typeof result.current.handleTabKeyDown).toBe('function');
       result.current.handleTabKeyDown(KEY_DOWN_EVENT);
-      expect(KEY_DOWN_EVENT.preventDefault).toBeCalledTimes(1);
-      expect(handleTokensCreate).toBeCalledTimes(1);
-      expect(handleTokensCreate).toBeCalledWith(inputValue);
+      expect(KEY_DOWN_EVENT.preventDefault).toHaveBeenCalledTimes(1);
+      expect(handleTokensCreate).toHaveBeenCalledTimes(1);
+      expect(handleTokensCreate).toHaveBeenCalledWith(inputValue);
     });
   });
 });

--- a/src/hooks/usePredefinedKeyDownHandlers.test.js
+++ b/src/hooks/usePredefinedKeyDownHandlers.test.js
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import usePredefinedKeyDownHandlers from './usePredefinedKeyDownHandlers.ts';
 import {
   KEY_DOWN_HANDLER_CONFIG_OPTION,

--- a/src/hooks/useTokenDelete.test.js
+++ b/src/hooks/useTokenDelete.test.js
@@ -24,9 +24,9 @@ describe('useTokenDelete() with default string type tokenValue', () => {
 
     const newTokenValues = [...tokenValues];
     newTokenValues.splice(MOCK_TARGET_INDEX, 1);
-    expect(onTokenValuesChange).toBeCalledTimes(1);
-    expect(onTokenValuesChange).toBeCalledWith(newTokenValues);
+    expect(onTokenValuesChange).toHaveBeenCalledTimes(1);
+    expect(onTokenValuesChange).toHaveBeenCalledWith(newTokenValues);
 
-    expect(focusTokenCreator).toBeCalledTimes(1);
+    expect(focusTokenCreator).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/hooks/useTokenDelete.test.js
+++ b/src/hooks/useTokenDelete.test.js
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import useTokenDelete from './useTokenDelete.ts';
 
 import DEFAULT_VALUE_TYPE_DATA from '../__fixtures__/tokenValues.fixtures';

--- a/src/hooks/useTokenEdit.test.js
+++ b/src/hooks/useTokenEdit.test.js
@@ -28,10 +28,10 @@ describe('useTokenEdit() with default string type tokenValue', () => {
       const MOCK_TARGET_INDEX = 2;
       result.current.handleTokenEditStart(MOCK_TARGET_INDEX)();
 
-      expect(setTokenActivated).toBeCalledTimes(1);
-      expect(setTokenActivated).toBeCalledWith(MOCK_TARGET_INDEX, true);
+      expect(setTokenActivated).toHaveBeenCalledTimes(1);
+      expect(setTokenActivated).toHaveBeenCalledWith(MOCK_TARGET_INDEX, true);
 
-      expect(handleTokenInputFocus).toBeCalledTimes(1);
+      expect(handleTokenInputFocus).toHaveBeenCalledTimes(1);
 
       expect(onTokenValuesChange).not.toBeCalled();
       expect(handleTokenInputBlur).not.toBeCalled();
@@ -62,10 +62,10 @@ describe('useTokenEdit() with default string type tokenValue', () => {
       const MOCK_TARGET_INDEX = 2;
       result.current.handleTokenEditEnd(MOCK_TARGET_INDEX)();
 
-      expect(setTokenActivated).toBeCalledTimes(1);
-      expect(setTokenActivated).toBeCalledWith(MOCK_TARGET_INDEX, false);
+      expect(setTokenActivated).toHaveBeenCalledTimes(1);
+      expect(setTokenActivated).toHaveBeenCalledWith(MOCK_TARGET_INDEX, false);
 
-      expect(handleTokenInputBlur).toBeCalledTimes(1);
+      expect(handleTokenInputBlur).toHaveBeenCalledTimes(1);
       expect(onTokenValuesChange).not.toBeCalled();
     });
 
@@ -93,15 +93,15 @@ describe('useTokenEdit() with default string type tokenValue', () => {
       const NEW_TOKEN_VALUE = 'new value';
       result.current.handleTokenEditEnd(MOCK_TARGET_INDEX)(NEW_TOKEN_VALUE);
 
-      expect(setTokenActivated).toBeCalledTimes(1);
-      expect(setTokenActivated).toBeCalledWith(MOCK_TARGET_INDEX, false);
+      expect(setTokenActivated).toHaveBeenCalledTimes(1);
+      expect(setTokenActivated).toHaveBeenCalledWith(MOCK_TARGET_INDEX, false);
 
-      expect(handleTokenInputBlur).toBeCalledTimes(1);
+      expect(handleTokenInputBlur).toHaveBeenCalledTimes(1);
 
       const modifiedTokenValues = [...tokenValues];
       modifiedTokenValues[MOCK_TARGET_INDEX] = NEW_TOKEN_VALUE;
-      expect(onTokenValuesChange).toBeCalledTimes(1);
-      expect(onTokenValuesChange).toBeCalledWith(modifiedTokenValues);
+      expect(onTokenValuesChange).toHaveBeenCalledTimes(1);
+      expect(onTokenValuesChange).toHaveBeenCalledWith(modifiedTokenValues);
     });
   });
 });

--- a/src/hooks/useTokenEdit.test.js
+++ b/src/hooks/useTokenEdit.test.js
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import useTokenEdit from './useTokenEdit.ts';
 
 import DEFAULT_VALUE_TYPE_DATA from '../__fixtures__/tokenValues.fixtures';

--- a/src/hooks/useTokenInputFocusEffect.test.js
+++ b/src/hooks/useTokenInputFocusEffect.test.js
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react';
 import useTokenInputFocusEffect from './useTokenInputFocusEffect.ts';
 
 describe('useTokenInputFocusEffect()', () => {

--- a/src/hooks/useTokenInputFocusEffect.test.js
+++ b/src/hooks/useTokenInputFocusEffect.test.js
@@ -51,7 +51,7 @@ describe('useTokenInputFocusEffect()', () => {
     act(() => {
       result.current.handleCreatorFocus(focusEvent);
     });
-    expect(onCreatorFocus).toBeCalledWith(focusEvent);
+    expect(onCreatorFocus).toHaveBeenCalledWith(focusEvent);
     expect(result.current.isTokenInputFocused).toBe(true);
   });
 
@@ -74,7 +74,7 @@ describe('useTokenInputFocusEffect()', () => {
     act(() => {
       result.current.handleCreatorBlur(focusEvent);
     });
-    expect(onCreatorBlur).toBeCalledWith(focusEvent);
+    expect(onCreatorBlur).toHaveBeenCalledWith(focusEvent);
     expect(result.current.isTokenInputFocused).toBe(false);
   });
 });

--- a/src/hooks/useTokenMetas.test.js
+++ b/src/hooks/useTokenMetas.test.js
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react';
 import useTokenMetas from './useTokenMetas.ts';
 
 import DEFAULT_VALUE_TYPE_DATA from '../__fixtures__/tokenValues.fixtures';

--- a/src/utils/keyDownHandlerProxy.test.js
+++ b/src/utils/keyDownHandlerProxy.test.js
@@ -24,8 +24,10 @@ describe('keyDownHandlerProxy()', () => {
     it('should execute onBackspace()', () => {
       keyDownHandlerProxy(MOCK_KEY_DONE_EVENT, MOCK_ACTIONS);
 
-      expect(MOCK_ACTIONS.onBackspace).toBeCalledWith(MOCK_KEY_DONE_EVENT);
-      expect(MOCK_ACTIONS.onBackspace).toBeCalledTimes(1);
+      expect(MOCK_ACTIONS.onBackspace).toHaveBeenCalledWith(
+        MOCK_KEY_DONE_EVENT,
+      );
+      expect(MOCK_ACTIONS.onBackspace).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -39,8 +41,8 @@ describe('keyDownHandlerProxy()', () => {
     it('should execute onTab()', () => {
       keyDownHandlerProxy(MOCK_KEY_DONE_EVENT, MOCK_ACTIONS);
 
-      expect(MOCK_ACTIONS.onTab).toBeCalledWith(MOCK_KEY_DONE_EVENT);
-      expect(MOCK_ACTIONS.onTab).toBeCalledTimes(1);
+      expect(MOCK_ACTIONS.onTab).toHaveBeenCalledWith(MOCK_KEY_DONE_EVENT);
+      expect(MOCK_ACTIONS.onTab).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -54,8 +56,8 @@ describe('keyDownHandlerProxy()', () => {
     it('should execute onEnter()', () => {
       keyDownHandlerProxy(MOCK_KEY_DONE_EVENT, MOCK_ACTIONS);
 
-      expect(MOCK_ACTIONS.onEnter).toBeCalledWith(MOCK_KEY_DONE_EVENT);
-      expect(MOCK_ACTIONS.onEnter).toBeCalledTimes(1);
+      expect(MOCK_ACTIONS.onEnter).toHaveBeenCalledWith(MOCK_KEY_DONE_EVENT);
+      expect(MOCK_ACTIONS.onEnter).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -69,8 +71,8 @@ describe('keyDownHandlerProxy()', () => {
     it('should execute onEnter()', () => {
       keyDownHandlerProxy(MOCK_KEY_DONE_EVENT, MOCK_ACTIONS);
 
-      expect(MOCK_ACTIONS.onEscape).toBeCalledWith(MOCK_KEY_DONE_EVENT);
-      expect(MOCK_ACTIONS.onEscape).toBeCalledTimes(1);
+      expect(MOCK_ACTIONS.onEscape).toHaveBeenCalledWith(MOCK_KEY_DONE_EVENT);
+      expect(MOCK_ACTIONS.onEscape).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,7 +15,7 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0", "@babel/code-frame@^7.23.5", "@babel/code-frame@^7.8.3":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0", "@babel/code-frame@^7.23.5", "@babel/code-frame@^7.8.3":
   version "7.23.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.23.5.tgz#9009b69a8c602293476ad598ff53e4562e15c244"
   integrity sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==
@@ -1764,13 +1764,28 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@testing-library/react-hooks@^8.0.1":
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
-  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+"@testing-library/dom@^9.0.0":
+  version "9.3.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-9.3.4.tgz#50696ec28376926fec0a1bf87d9dbac5e27f60ce"
+  integrity sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "5.1.3"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.5.0"
+    pretty-format "^27.0.2"
+
+"@testing-library/react@^14.2.1":
+  version "14.2.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-14.2.1.tgz#bf69aa3f71c36133349976a4a2da3687561d8310"
+  integrity sha512-sGdjws32ai5TLerhvzThYFbpnF9XtL65Cjf+gB0Dhr29BGqK+mAeN7SURSdu+eqgET4ANcWoC7FQpkaiGvBr+A==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    react-error-boundary "^3.1.0"
+    "@testing-library/dom" "^9.0.0"
+    "@types/react-dom" "^18.0.0"
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -1786,6 +1801,11 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
+
+"@types/aria-query@^5.0.1":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
+  integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
 
 "@types/babel__core@^7.1.14":
   version "7.20.5"
@@ -2014,6 +2034,13 @@
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
+
+"@types/react-dom@^18.0.0":
+  version "18.2.19"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.19.tgz#b84b7c30c635a6c26c6a6dfbb599b2da9788be58"
+  integrity sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-input-autosize@^2.2.4":
   version "2.2.4"
@@ -2582,6 +2609,13 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+aria-query@5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.1.3.tgz#19db27cd101152773631396f7a95a3b58c22c35e"
+  integrity sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==
+  dependencies:
+    deep-equal "^2.0.5"
+
 aria-query@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
@@ -2589,7 +2623,7 @@ aria-query@^5.3.0:
   dependencies:
     dequal "^2.0.3"
 
-array-buffer-byte-length@^1.0.1:
+array-buffer-byte-length@^1.0.0, array-buffer-byte-length@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz#1e5583ec16763540a27ae52eed99ff899223568f"
   integrity sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==
@@ -3646,6 +3680,30 @@ dedent@^1.0.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.5.1.tgz#4f3fc94c8b711e9bb2800d185cd6ad20f2a90aff"
   integrity sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==
 
+deep-equal@^2.0.5:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.2.3.tgz#af89dafb23a396c7da3e862abc0be27cf51d56e1"
+  integrity sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==
+  dependencies:
+    array-buffer-byte-length "^1.0.0"
+    call-bind "^1.0.5"
+    es-get-iterator "^1.1.3"
+    get-intrinsic "^1.2.2"
+    is-arguments "^1.1.1"
+    is-array-buffer "^3.0.2"
+    is-date-object "^1.0.5"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    isarray "^2.0.5"
+    object-is "^1.1.5"
+    object-keys "^1.1.1"
+    object.assign "^4.1.4"
+    regexp.prototype.flags "^1.5.1"
+    side-channel "^1.0.4"
+    which-boxed-primitive "^1.0.2"
+    which-collection "^1.0.1"
+    which-typed-array "^1.1.13"
+
 deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
@@ -3784,6 +3842,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -4012,6 +4075,21 @@ es-errors@^1.0.0, es-errors@^1.1.0, es-errors@^1.2.1, es-errors@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
+es-get-iterator@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.3.tgz#3ef87523c5d464d41084b2c3c9c214f1199763d6"
+  integrity sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.3"
+    has-symbols "^1.0.3"
+    is-arguments "^1.1.1"
+    is-map "^2.0.2"
+    is-set "^2.0.2"
+    is-string "^1.0.7"
+    isarray "^2.0.5"
+    stop-iteration-iterator "^1.0.0"
 
 es-iterator-helpers@^1.0.12, es-iterator-helpers@^1.0.15:
   version "1.0.17"
@@ -5393,7 +5471,7 @@ ini@^1.3.5:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
-internal-slot@^1.0.5, internal-slot@^1.0.7:
+internal-slot@^1.0.4, internal-slot@^1.0.5, internal-slot@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.7.tgz#c06dcca3ed874249881007b0a5523b172a190802"
   integrity sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==
@@ -5425,7 +5503,15 @@ ipaddr.js@^2.1.0:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.1.0.tgz#2119bc447ff8c257753b196fc5f1ce08a4cdf39f"
   integrity sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==
 
-is-array-buffer@^3.0.4:
+is-arguments@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
+  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
+is-array-buffer@^3.0.2, is-array-buffer@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.4.tgz#7a1f92b3d61edd2bc65d24f130530ea93d7fae98"
   integrity sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==
@@ -5544,7 +5630,7 @@ is-lambda@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-lambda/-/is-lambda-1.0.1.tgz#3d9877899e6a53efc0160504cde15f82e6f061d5"
   integrity sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==
 
-is-map@^2.0.1:
+is-map@^2.0.1, is-map@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127"
   integrity sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==
@@ -5616,7 +5702,7 @@ is-root@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-root/-/is-root-2.1.0.tgz#809e18129cf1129644302a4f8544035d51984a9c"
   integrity sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==
 
-is-set@^2.0.1:
+is-set@^2.0.1, is-set@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.2.tgz#90755fa4c2562dc1c5d4024760d6119b94ca18ec"
   integrity sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==
@@ -6487,6 +6573,11 @@ lru-cache@^7.7.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.0.tgz#0bd445ca57363465900f4d1f9bd8db343a4d95c3"
   integrity sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==
 
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
+
 make-dir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
@@ -6989,6 +7080,14 @@ object-inspect@^1.13.1:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.1.tgz#b96c6109324ccfef6b12216a956ca4dc2ff94bc2"
   integrity sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==
+
+object-is@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.6.tgz#1a6a53aed2dd8f7e6775ff870bea58545956ab07"
+  integrity sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==
+  dependencies:
+    call-bind "^1.0.7"
+    define-properties "^1.2.1"
 
 object-keys@^1.1.1:
   version "1.1.1"
@@ -7907,6 +8006,15 @@ pretty-error@^4.0.0:
     lodash "^4.17.20"
     renderkid "^3.0.0"
 
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 pretty-format@^29.0.0, pretty-format@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
@@ -8056,13 +8164,6 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
-react-error-boundary@^3.1.0:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
-  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-
 react-error-overlay@^6.0.11:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
@@ -8079,6 +8180,11 @@ react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-is@^18.0.0:
   version "18.2.0"
@@ -8199,7 +8305,7 @@ regenerator-transform@^0.15.2:
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-regexp.prototype.flags@^1.5.0, regexp.prototype.flags@^1.5.2:
+regexp.prototype.flags@^1.5.0, regexp.prototype.flags@^1.5.1, regexp.prototype.flags@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz#138f644a3350f981a858c44f6bb1a61ff59be334"
   integrity sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==
@@ -8809,6 +8915,13 @@ stdout-stream@^1.4.0:
   integrity sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==
   dependencies:
     readable-stream "^2.0.1"
+
+stop-iteration-iterator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz#6a60be0b4ee757d1ed5254858ec66b10c49285e4"
+  integrity sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==
+  dependencies:
+    internal-slot "^1.0.4"
 
 string-hash@^1.1.1:
   version "1.1.3"
@@ -9797,7 +9910,7 @@ which-collection@^1.0.1:
     is-weakmap "^2.0.1"
     is-weakset "^2.0.1"
 
-which-typed-array@^1.1.14, which-typed-array@^1.1.9:
+which-typed-array@^1.1.13, which-typed-array@^1.1.14, which-typed-array@^1.1.9:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.14.tgz#1f78a111aee1e131ca66164d8bdc3ab062c95a06"
   integrity sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==


### PR DESCRIPTION
### [Issue]

- Got warning on dependency: `warning " > @testing-library/react-hooks@8.0.1" has incorrect peer dependency "react@^16.9.0 || ^17.0.0".`
- When running unit-test got a warning from library `@testing-library/react-hooks` too. For instance: 
```
    console.error
      Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot

      13 |       const handleTokenInputBlur = jest.fn();
      14 |
    > 15 |       const { result } = renderHook(() =>
         |                                    ^
      16 |         useTokenEdit({
      17 |           tokenValues,
      18 |           onTokenValuesChange,

      at console.error (node_modules/@testing-library/react-hooks/lib/core/console.js:19:7)
      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:86:30)
      at error (node_modules/react-dom/cjs/react-dom.development.js:60:7)
      at Object.render (node_modules/react-dom/cjs/react-dom.development.js:29670:5)
      at node_modules/@testing-library/react-hooks/lib/dom/pure.js:80:18
      at act (node_modules/react/cjs/react.development.js:2512:16)
      at render (node_modules/@testing-library/react-hooks/lib/dom/pure.js:79:26)
      at renderHook (node_modules/@testing-library/react-hooks/lib/core/index.js:114:5)
      at Object.<anonymous> (src/hooks/useTokenEdit.test.js:15:36)
```
![截圖 2024-03-03 19 42 00](https://github.com/seawind543/react-token-input/assets/27720673/6373aa66-76ac-43bc-99fa-b101e9bdf601)

### [Root cause]
- After the release of React 18 the [authors of Testing Library decided](https://github.com/testing-library/react-hooks-testing-library#details) to integrate the renderHook utility directly into @testing-library/react instead of maintaining a separated package for this API.

Reference: https://dev.to/alexclaes/test-a-hook-throwing-errors-in-react-18-with-renderhook-from-testing-library-20g8

### [Solution]
- Migrate `@testing-library/react-hooks` to `@testing-library/react`

### [Additional changes]
Also, took the recommended Jest method names