### PR TITLE
doc: [#141] deprecate polyfill.io in live-demo page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,9 +7,9 @@
 <meta name="description" content="">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
-<script defer src="bundle.js?c9222b4779b08c6ad94c"></script></head>
+<script defer src="bundle.js?9619a64295070c6b9ba9"></script></head>
 <body>
 <div id="container"></div>
-<script src="https://polyfill.io/v3/polyfill.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,9 +7,9 @@
 <meta name="description" content="">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
-<script defer src="bundle.js?9619a64295070c6b9ba9"></script></head>
+<script defer src="bundle.js?aad3e691edad08004671"></script></head>
 <body>
 <div id="container"></div>
-<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -10,6 +10,6 @@
 </head>
 <body>
 <div id="container"></div>
-<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -10,6 +10,6 @@
 </head>
 <body>
 <div id="container"></div>
-<script src="https://polyfill.io/v3/polyfill.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Deprecate `https://polyfill.io/` by replacing it with `https://cdnjs.cloudflare.com/polyfill/`