### PR TITLE
doc: deprecate the polyfill from the demo page to avoid confusion

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,9 +7,8 @@
 <meta name="description" content="">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
-<script defer src="bundle.js?4ddb1f5f1c8ed8feab9c"></script></head>
+<script defer src="bundle.js?5e5babbabc3434915f2d"></script></head>
 <body>
 <div id="container"></div>
-<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -10,6 +10,5 @@
 </head>
 <body>
 <div id="container"></div>
-<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0" crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
The polyfill file is applied for the demo page only, however it is in the repo of this library and confused people. Since the modern browser does not need polyfill, it should be fine to remove it from the demo page.