### PR TITLE
React 19 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/seawind543/react-token-input",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^16.10.2 || ^17.0.0 || ^18.0.0"
+    "react": "^16.10.2 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "classnames": "^2.5.1",


### PR DESCRIPTION
Added React v19 to the peer dependency list. It works just fine without any breaking changes, tested myself.

```
npm error While resolving: react-customize-token-input@2.6.1
npm error Found: react@19.0.0
```